### PR TITLE
Fix Unity scene parsing error

### DIFF
--- a/Assets/Scenes/Arena.unity
+++ b/Assets/Scenes/Arena.unity
@@ -56,7 +56,7 @@ Camera:
   m_Depth: -1
   m_CullingMask:
     serializedVersion: 2
-    m_Bits: -1
+    m_Bits: 4294967295
   m_RenderingPath: -1
   m_TargetTexture: {fileID: 0}
   m_TargetDisplay: 0


### PR DESCRIPTION
## Summary
- resolve negative culling mask value in `Arena.unity` scene

## Testing
- `grep -n '\-1' Assets/Scenes/Arena.unity | tail`

------
https://chatgpt.com/codex/tasks/task_e_686b9dde6cec832ea4f6d15fed6e3024