### PR TITLE
Fix Unity broken references by including meta files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,4 +23,3 @@ obj/
 *.apk
 *.aab
 
-*.meta

--- a/Assets/Scenes/Arena.unity.meta
+++ b/Assets/Scenes/Arena.unity.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: ee965f0400794af29cb763ab27e7fadf
+SceneImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:
+  activeSubScenes: []

--- a/Assets/Scripts/Bullet.cs.meta
+++ b/Assets/Scripts/Bullet.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3246beecf430452dbcf514ffe33bfb92
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/CameraFollow.cs.meta
+++ b/Assets/Scripts/CameraFollow.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8348b86c87194ad6bbb17cebef928b0b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/EnemyAI.cs.meta
+++ b/Assets/Scripts/EnemyAI.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c976866b53874c6c8031c5c8a9669797
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/GameManager.cs.meta
+++ b/Assets/Scripts/GameManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: fcdcbe207ab54fee96b4d4ec0d25ed2a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/PlayerController.cs.meta
+++ b/Assets/Scripts/PlayerController.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9337b6cb42744938924227dbac57c8ab
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/PlayerHealth.cs.meta
+++ b/Assets/Scripts/PlayerHealth.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 06a3c81aacfa4acfbfc570dfb6e6005e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/SkillSystem.cs.meta
+++ b/Assets/Scripts/SkillSystem.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d91d2b816e81406db27823fd3aaeef42
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/SpawnManager.cs.meta
+++ b/Assets/Scripts/SpawnManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: dfbf935134364f90901be48fb50c7d6f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/UIManager.cs.meta
+++ b/Assets/Scripts/UIManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 98f77f03e354418aba4cc8cc3fb695ff
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Weapon.cs.meta
+++ b/Assets/Scripts/Weapon.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5285f0a7188b4f9dbfeda7b147c1efa1
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## Summary
- keep Unity `.meta` files under version control
- add `.meta` files for the scene and scripts so Unity preserves references

## Testing
- `true`


------
https://chatgpt.com/codex/tasks/task_e_686ba49c97d8832e8cedf870c132a0e9